### PR TITLE
Feed Importer

### DIFF
--- a/app/feedperson/tests.py
+++ b/app/feedperson/tests.py
@@ -24,11 +24,3 @@ class FeedPersonTestCase(TestCase):
     non_western_ave_people = filter(lambda person: "Western Ave" not in person.location, FeedPerson.objects.all())
     self.assertTrue(len(list(western_ave_people)) > 0)
     self.assertEqual(len(list(non_western_ave_people)), 0)
-
-  def test_load_feed_people_returns_expected_keys(self):
-    expected_keys = ['eppn', 'firstname', 'lastname', 'name', 'location']
-    actual_keys = FeedPerson.objects.all().values()[0].keys()
-    for key in expected_keys:
-      self.assertTrue(key in actual_keys)
-    # The actual keys includes a primary key
-    self.assertEqual(len(actual_keys), len(expected_keys) + 1)

--- a/app/feedperson/tests.py
+++ b/app/feedperson/tests.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
-
 from .models import FeedPerson
+from feedperson.utils import load_feed_people
 
 # Create your tests here.
 class FeedPersonTestCase(TestCase):
@@ -12,3 +12,23 @@ class FeedPersonTestCase(TestCase):
   def test_str_value(self):
     feed_person = FeedPerson.objects.get(id=1)
     self.assertEqual(feed_person.name, str(feed_person))
+
+  def test_load_feed_people_removes_original_data(self):
+    feed_person = FeedPerson.objects.get(id=1)
+    load_feed_people()
+    self.assertEqual(FeedPerson.objects.filter(eppn=feed_person.eppn).count(), 0)
+
+  def test_load_feed_people_imports_western_ave_people(self):
+    load_feed_people()
+    western_ave_people = filter(lambda person: "Western Ave" in person.location, FeedPerson.objects.all())
+    non_western_ave_people = filter(lambda person: "Western Ave" not in person.location, FeedPerson.objects.all())
+    self.assertTrue(len(list(western_ave_people)) > 0)
+    self.assertEqual(len(list(non_western_ave_people)), 0)
+
+  def test_load_feed_people_returns_expected_keys(self):
+    expected_keys = ['eppn', 'firstname', 'lastname', 'name', 'location']
+    actual_keys = FeedPerson.objects.all().values()[0].keys()
+    for key in expected_keys:
+      self.assertTrue(key in actual_keys)
+    # The actual keys includes a primary key
+    self.assertEqual(len(actual_keys), len(expected_keys) + 1)

--- a/app/feedperson/utils.py
+++ b/app/feedperson/utils.py
@@ -29,4 +29,3 @@ def load_feed_people():
   
   load_rollup()
 
-  return HttpResponse("Successfully imported FeedPerson data.")

--- a/app/feedperson/utils.py
+++ b/app/feedperson/utils.py
@@ -1,0 +1,32 @@
+from feedperson.models import FeedPerson
+from urllib.request import urlopen
+import re
+from bs4 import BeautifulSoup
+from django.http import HttpResponse
+from rollup.utils import load_rollup
+
+def load_feed_people():
+  # Remove the existing FeedPerson data before importing updated data
+  FeedPerson.objects.all().delete()
+
+  with urlopen('https://nodefeeds.seas.harvard.edu/app/api/person/list/active') as file:
+    feed_contents = file.read().decode('utf-8')
+
+  soup = BeautifulSoup(feed_contents, 'html.parser')
+
+  people = soup.findAll('person')
+
+  for person in people:
+    location = person.location.fordisp.text
+    if (re.match('114 Western Ave', location) or re.match('150 Western Ave', location)):
+      FeedPerson.objects.create(
+        eppn=person.eppn.text,
+        firstname=person.givenname.text,
+        lastname=person.lastname.text,
+        name=person.gecos.text,
+        location=location
+      )
+  
+  load_rollup()
+
+  return HttpResponse("Successfully imported FeedPerson data.")

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,4 +1,4 @@
 Django==3.1.5
 gunicorn==20.0.4
 psycopg2
-
+beautifulsoup4==4.9.3


### PR DESCRIPTION
The `load_feed_people` function removes all of the existing `FeedPerson` data before importing updated data from the active SEAS feed. This uses BeautifulSoup to parse the data, filters for people with a location of 114 Western Ave or 150 Western Ave, and generates new `FeedPerson` data objects with the keys `eppn`, `firstname`, `lastname`, `name`, and `location`. Then it calls the `load_rollup` function to generate `Rollup` objects from the new `FeedPerson` objects and returns an `HttpResponse` to indicate that the data import was successful.

Fixes #14 