### PR TITLE
Feature/8 GitHub actions

### DIFF
--- a/.github/workflows/01-test.yml
+++ b/.github/workflows/01-test.yml
@@ -9,6 +9,9 @@ jobs:
     name: Run full test suite
     runs-on: ubuntu-latest
     container: python:3.8.0-alpine
+    defaults:
+      run:
+        working-directory: app
     env: 
       SQL_ENGINE: django.db.backends.postgresql
       SQL_DATABASE: directory
@@ -35,8 +38,8 @@ jobs:
           apk update
           apk add postgresql-dev gcc python3-dev musl-dev
           python -m pip install --upgrade pip
-          pip install -r app/requirements.txt
+          pip install -r requirements.txt
       - name: Run database migrations
-        run: python app/manage.py migrate
+        run: python manage.py migrate
       - name: Django Tests 
-        run: python app/manage.py test
+        run: python manage.py test

--- a/.github/workflows/01-test.yml
+++ b/.github/workflows/01-test.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r app/requirements.txt
       - name: Run database migrations
         run: python manage.py migrate
       - name: Django Tests 

--- a/.github/workflows/01-test.yml
+++ b/.github/workflows/01-test.yml
@@ -49,6 +49,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - name: login
         uses: docker/login-action@v1
         with:
@@ -58,7 +59,7 @@ jobs:
       - name: Publish stable image
         uses: docker/build-push-action@v2
         with:
-          context: app/
+          context: app
           file: Dockerfile.prod
           push: true
           tags: ghcr.io/${{ github.repository }}:stable

--- a/.github/workflows/01-test.yml
+++ b/.github/workflows/01-test.yml
@@ -43,3 +43,25 @@ jobs:
         run: python manage.py migrate
       - name: Django Tests 
         run: python manage.py test
+  build:
+    name: Build Docker Container
+    # if: github.event_name == 'push' && github.ref == 'main'
+    needs: test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app
+    steps:
+      - uses: actions/checkout@v2
+      - name: login
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      - name: Publish stable image
+        uses: docker/build-push-action@v2
+        with:
+          file: Dockerfile.prod
+          push: true
+          tags: ghcr.io/${{ github.repository }}:stable

--- a/.github/workflows/01-test.yml
+++ b/.github/workflows/01-test.yml
@@ -13,7 +13,7 @@ jobs:
       SQL_DATABASE: directory
       SQL_USER: developer
       SQL_PASSWORD: password
-      SQL_HOST: db
+      SQL_HOST: postgres
       SQL_PORT: 5432
     services:
       postgres:

--- a/.github/workflows/01-test.yml
+++ b/.github/workflows/01-test.yml
@@ -37,6 +37,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r app/requirements.txt
       - name: Run database migrations
-        run: python manage.py migrate
+        run: python app/manage.py migrate
       - name: Django Tests 
-        run: python manage.py test
+        run: python app/manage.py test

--- a/.github/workflows/01-test.yml
+++ b/.github/workflows/01-test.yml
@@ -1,0 +1,42 @@
+name: Testing
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+jobs:
+  test:
+    name: Run full test suite
+    runs-on: ubuntu-latest
+    env: 
+      SQL_ENGINE: django.db.backends.postgresql
+      SQL_DATABASE: directory
+      SQL_USER: developer
+      SQL_PASSWORD: password
+      SQL_HOST: db
+      SQL_PORT: 5432
+    services:
+      postgres:
+        image: postgres
+        env: 
+          POSTGRES_DATABASE: directory
+          POSTGRES_USER: developer
+          POSTGRES_PASSWORD: password
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run database migrations
+        run: python manage.py migrate
+      - name: Django Tests 
+        run: python manage.py test

--- a/.github/workflows/01-test.yml
+++ b/.github/workflows/01-test.yml
@@ -8,6 +8,7 @@ jobs:
   test:
     name: Run full test suite
     runs-on: ubuntu-latest
+    container: python:3.8.0-alpine
     env: 
       SQL_ENGINE: django.db.backends.postgresql
       SQL_DATABASE: directory
@@ -29,11 +30,10 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
-        with:
-          python-version: 3.8
       - name: Install Dependencies
         run: |
+          apk update
+          apk add postgresql-dev gcc python3-dev musl-dev
           python -m pip install --upgrade pip
           pip install -r app/requirements.txt
       - name: Run database migrations

--- a/.github/workflows/01-test.yml
+++ b/.github/workflows/01-test.yml
@@ -60,6 +60,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: app
-          file: Dockerfile.prod
+          file: ./app/Dockerfile.prod
           push: true
           tags: ghcr.io/${{ github.repository }}:stable

--- a/.github/workflows/01-test.yml
+++ b/.github/workflows/01-test.yml
@@ -45,7 +45,7 @@ jobs:
         run: python manage.py test
   build:
     name: Build Docker Container
-    # if: github.event_name == 'push' && github.ref == 'main'
+    if: github.event_name == 'push' && github.ref == 'main'
     needs: test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/01-test.yml
+++ b/.github/workflows/01-test.yml
@@ -20,7 +20,7 @@ jobs:
       postgres:
         image: postgres
         env: 
-          POSTGRES_DATABASE: directory
+          POSTGRES_DB: directory
           POSTGRES_USER: developer
           POSTGRES_PASSWORD: password
         options: >-

--- a/.github/workflows/01-test.yml
+++ b/.github/workflows/01-test.yml
@@ -48,11 +48,7 @@ jobs:
     # if: github.event_name == 'push' && github.ref == 'main'
     needs: test
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: app
     steps:
-      - uses: actions/checkout@v2
       - name: login
         uses: docker/login-action@v1
         with:
@@ -62,6 +58,7 @@ jobs:
       - name: Publish stable image
         uses: docker/build-push-action@v2
         with:
+          context: app/
           file: Dockerfile.prod
           push: true
           tags: ghcr.io/${{ github.repository }}:stable

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,4 +1,5 @@
-name: Testing
+name: Test and Build
+# Runs on all pushes and PR's
 on:
   push:
     branches:
@@ -6,23 +7,27 @@ on:
   pull_request:
 jobs:
   test:
-    name: Run full test suite
+    name: Run test suite
     runs-on: ubuntu-latest
+    # Run our tests on the alpine container
     container: python:3.8.0-alpine
     defaults:
       run:
         working-directory: app
     env: 
+      # Django specific environment
       SQL_ENGINE: django.db.backends.postgresql
       SQL_DATABASE: directory
       SQL_USER: developer
       SQL_PASSWORD: password
       SQL_HOST: postgres
       SQL_PORT: 5432
+    # Separately, run a postgres container to test against
     services:
       postgres:
         image: postgres
         env: 
+          # POSTGRES specific environment (must match Django SQL_* values above)
           POSTGRES_DB: directory
           POSTGRES_USER: developer
           POSTGRES_PASSWORD: password
@@ -33,6 +38,7 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v2
+        # Pip and system dependencies needed inside the container
       - name: Install Dependencies
         run: |
           apk update
@@ -45,6 +51,7 @@ jobs:
         run: python manage.py test
   build:
     name: Build Docker Container
+    # Only build container when code has been merged into main
     if: github.event_name == 'push' && github.ref == 'main'
     needs: test
     runs-on: ubuntu-latest

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -52,7 +52,7 @@ jobs:
   build:
     name: Build Docker Container
     # Only build container when code has been merged into main
-    if: github.event_name == 'push' && github.ref == 'main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: test
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR implements a single GitHub Actions workflow that runs all of our tests on every push or PR, then builds the docker image when there's a push a `main` (provided that the tests all pass). Keeping everything in a single workflow makes it a little easier to manage the dependencies on the test stage completing before the docker stage runs. Since this project is fairly limited in scope it shouldn't need the full range of workflows that we've used in the course-planner

I did end up pushing a bunch of little commits while debugging why certain steps were failing. I've opted not to squash those in case the process to arrive here is useful in the future. (If you want to go _really_ deep, you can also back and see what specific failures were raised in each run by cross-referencing the commits).

The ultimate outcome is that our container is published to https://github.com/seas-computing/sec-directory-server/pkgs/container/sec-directory-server. You can test it locally changin:

```yaml
services:
  web:
    build:
      context: ./app
      dockerfile: Dockerfile.prod
```  

to

```yaml
services:
  web:
    image: ghcr.io/seas-computing/sec-directory-server:stable
```

in the docker-compose file and bringing it up like normal. 