### PR TITLE
Implemented a clear-index function to be used with load_rollup. 

### DIFF
--- a/app/rollup/utils.py
+++ b/app/rollup/utils.py
@@ -5,7 +5,7 @@ from person.models import Person
 from feedperson.models import FeedPerson
 from algoliasearch.search_client import SearchClient
 
-# Function to force a clear out of the index before reindexing.
+# Forcees a clear-out of the index before reindexing.
 # Prevents duplicate records being created if updates are pushed from two different DBs.
 # This could happen if the production machine / DB are rebuilt.
 def clear_index():
@@ -27,6 +27,3 @@ def load_rollup():
         name = object.name,
         location = object.location
       )
-
-
-

--- a/app/rollup/utils.py
+++ b/app/rollup/utils.py
@@ -1,10 +1,21 @@
+from os import environ
 from .models import Rollup
 from place.models import Place
 from person.models import Person
 from feedperson.models import FeedPerson
+from algoliasearch.search_client import SearchClient
+
+# Function to force a clear out of the index before reindexing.
+# Prevents duplicate records being created if updates are pushed from two different DBs.
+# This could happen if the production machine / DB are rebuilt.
+def clear_index():
+  client = SearchClient.create(environ.get("ALGOLIA_APP_ID"), environ.get("ALGOLIA_API_KEY"))
+  index = client.init_index(environ.get("ALGOLIA_INDEX"))
+  index.clear_objects()
 
 # Creates updated Rollup objects using Place, Person, and FeedPerson data
 def load_rollup():
+  clear_index()
   Rollup.objects.all().delete()
   places = Place.objects.all()
   people = Person.objects.all()
@@ -16,3 +27,6 @@ def load_rollup():
         name = object.name,
         location = object.location
       )
+
+
+


### PR DESCRIPTION
Our Algolia indices are depending on the ID of the records in Django to determine whether or not to update or create records at index time. Sometimes IDs for identical records can be different, for example if two developers are working on the same index from their different dev machines, or if production DB were to be rebuilt. In this case, duplicate records would be created, one set for each developer's database.

This function prevents duplicate records being created by forcing the index to be cleared before pushing the records to Algolia.

No tests are included here, as testing would clear out the index currently being used by the application, which isn't desirable. Also, we would just be testing the Aloglia library's functionality.
