### PR TITLE
Django Admin: "Update Screens" Button

### DIFF
--- a/app/app/settings/base.py
+++ b/app/app/settings/base.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django_object_actions',
 ]
 
 MIDDLEWARE = [

--- a/app/person/admin.py
+++ b/app/person/admin.py
@@ -1,5 +1,18 @@
-from django.contrib import admin
-
+from django.contrib import admin, messages
+from rollup.utils import load_rollup
+from django_object_actions import DjangoObjectActions
 from .models import Person
-# Register your models here.
-admin.site.register(Person)
+
+# Adds a button to the Person Admin page to allow users to manually update the
+# directory screens with the most up-to-date data
+class PersonAdmin(DjangoObjectActions, admin.ModelAdmin):
+
+  def UpdateScreens(self, request, queryset):
+    load_rollup()
+    self.message_user(request, 'Successfully updated screens with revised person and place data.', level=messages.SUCCESS, fail_silently=False)
+  
+  UpdateScreens.label = 'Update screens'
+        
+  changelist_actions = ('UpdateScreens', )
+
+admin.site.register(Person, PersonAdmin)

--- a/app/person/admin.py
+++ b/app/person/admin.py
@@ -12,6 +12,8 @@ class PersonAdmin(DjangoObjectActions, admin.ModelAdmin):
     self.message_user(request, 'Successfully updated screens with revised person and place data.', level=messages.SUCCESS, fail_silently=False)
   
   UpdateScreens.label = 'Update screens'
+
+  UpdateScreens.short_description = 'Manually refresh the screens with the most recent data.'
         
   changelist_actions = ('UpdateScreens', )
 

--- a/app/person/admin.py
+++ b/app/person/admin.py
@@ -1,20 +1,5 @@
-from django.contrib import admin, messages
-from rollup.utils import load_rollup
-from django_object_actions import DjangoObjectActions
+from django.contrib import admin
+from rollup.utils import load_rollup, UpdateScreens
 from .models import Person
 
-# Adds a button to the Person Admin page to allow users to manually update the
-# directory screens with the most up-to-date data
-class PersonAdmin(DjangoObjectActions, admin.ModelAdmin):
-
-  def UpdateScreens(self, request, queryset):
-    load_rollup()
-    self.message_user(request, 'Successfully updated screens with revised person and place data.', level=messages.SUCCESS, fail_silently=False)
-  
-  UpdateScreens.label = 'Update screens'
-
-  UpdateScreens.short_description = 'Manually refresh the screens with the most recent data.'
-        
-  changelist_actions = ('UpdateScreens', )
-
-admin.site.register(Person, PersonAdmin)
+admin.site.register(Person, UpdateScreens)

--- a/app/person/tests.py
+++ b/app/person/tests.py
@@ -1,6 +1,13 @@
-from django.test import TestCase
+from django.test import TestCase, Client
+from django.contrib.auth.models import User
 
 from .models import Person
+
+test_username = 'test'
+test_email = 'test@test.com'
+test_password = 'TesterPassword'
+update_screens_button_label = 'Update screens'
+success_message = 'Successfully updated screens with revised person and place data.'
 
 # Create your tests here.
 class PersonTestCase(TestCase):
@@ -32,3 +39,23 @@ class PersonTestCase(TestCase):
     person = Person.objects.get(id=1)
     label = person._meta.get_field('name').verbose_name
     self.assertEqual(label, 'Full name')
+  
+  def test_update_screens_button_renders(self):
+    User.objects.create_superuser(test_username, test_email, test_password)
+
+    c = Client()
+    c.login(username=test_username, password=test_password)
+    response = c.get('/admin/person/person/')
+  
+    self.assertEqual(response.status_code, 200)
+    self.assertTrue(update_screens_button_label in response.content.decode('utf-8'))
+
+  def test_click_update_screens_button_result(self):
+    User.objects.create_superuser(test_username, test_email, test_password)
+
+    c = Client()
+    c.login(username=test_username, password=test_password)
+    response = c.get('/admin/person/person/actions/UpdateScreens/', follow=True)
+
+    self.assertEqual(response.status_code, 200)
+    self.assertTrue(success_message in response.content.decode('utf-8'))

--- a/app/person/tests.py
+++ b/app/person/tests.py
@@ -9,6 +9,7 @@ test_email = 'test@test.com'
 test_password = 'TesterPassword'
 update_screens_button_label = 'Update screens'
 success_message = 'Successfully updated screens with revised person and place data.'
+c = Client()
 
 # Create your tests here.
 class PersonTestCase(TestCase):
@@ -16,6 +17,8 @@ class PersonTestCase(TestCase):
   @classmethod
   def setUpTestData(cls):
     person = Person.objects.create(firstname="Jane", lastname="Harvard", location="SEC Room 322", name="Jane Harvard")
+    User.objects.create_superuser(test_username, test_email, test_password)
+    c.login(username=test_username, password=test_password)
 
   def test_str_value(self):
     person = Person.objects.get(id=1)
@@ -42,20 +45,12 @@ class PersonTestCase(TestCase):
     self.assertEqual(label, 'Full name')
   
   def test_update_screens_button_renders(self):
-    User.objects.create_superuser(test_username, test_email, test_password)
-
-    c = Client()
-    c.login(username=test_username, password=test_password)
     response = c.get('/admin/person/person/')
   
     self.assertEqual(response.status_code, 200)
     self.assertTrue(update_screens_button_label in response.content.decode('utf-8'))
 
   def test_click_update_screens_button_result(self):
-    User.objects.create_superuser(test_username, test_email, test_password)
-
-    c = Client()
-    c.login(username=test_username, password=test_password)
     with disable_auto_indexing():
       response = c.get('/admin/person/person/actions/UpdateScreens/', follow=True)
 

--- a/app/person/tests.py
+++ b/app/person/tests.py
@@ -55,7 +55,8 @@ class PersonTestCase(TestCase):
 
     c = Client()
     c.login(username=test_username, password=test_password)
-    response = c.get('/admin/person/person/actions/UpdateScreens/', follow=True)
+    with disable_auto_indexing():
+      response = c.get('/admin/person/person/actions/UpdateScreens/', follow=True)
 
     self.assertEqual(response.status_code, 200)
     self.assertTrue(success_message in response.content.decode('utf-8'))

--- a/app/person/tests.py
+++ b/app/person/tests.py
@@ -1,6 +1,8 @@
 from django.test import TestCase, Client
 from django.contrib.auth.models import User
 from algoliasearch_django.decorators import disable_auto_indexing
+import requests
+from unittest.mock import patch
 
 from .models import Person
 
@@ -9,6 +11,7 @@ test_email = 'test@test.com'
 test_password = 'TesterPassword'
 update_screens_button_label = 'Update screens'
 success_message = 'Successfully updated screens with revised person and place data.'
+error_message = 'Error: Unable to update screens. If the problem persists, contact SEAS Computing.'
 c = Client()
 
 # Create your tests here.
@@ -44,15 +47,22 @@ class PersonTestCase(TestCase):
     label = person._meta.get_field('name').verbose_name
     self.assertEqual(label, 'Full name')
   
-  def test_update_screens_button_renders(self):
+  def test_person_update_screens_button_renders(self):
     response = c.get('/admin/person/person/')
   
     self.assertEqual(response.status_code, 200)
     self.assertTrue(update_screens_button_label in response.content.decode('utf-8'))
 
-  def test_click_update_screens_button_result(self):
+  def test_click_person_update_screens_button_successful_result(self):
     with disable_auto_indexing():
-      response = c.get('/admin/person/person/actions/UpdateScreens/', follow=True)
+      response = c.get('/admin/person/person/actions/UpdateScreensButton/', follow=True)
 
     self.assertEqual(response.status_code, 200)
     self.assertTrue(success_message in response.content.decode('utf-8'))
+
+  @patch('rollup.utils.load_rollup')
+  def test_click_person_update_screens_button_error(self, mock_load_rollup):
+    mock_load_rollup.side_effect = Exception('Test error')
+    with disable_auto_indexing():
+      response = c.get('/admin/person/person/actions/UpdateScreensButton/', follow=True)
+    self.assertTrue(error_message in response.content.decode('utf-8'))

--- a/app/person/tests.py
+++ b/app/person/tests.py
@@ -1,5 +1,6 @@
 from django.test import TestCase, Client
 from django.contrib.auth.models import User
+from algoliasearch_django.decorators import disable_auto_indexing
 
 from .models import Person
 

--- a/app/place/admin.py
+++ b/app/place/admin.py
@@ -1,6 +1,18 @@
-from django.contrib import admin
-
+from django.contrib import admin, messages
+from rollup.utils import load_rollup
+from django_object_actions import DjangoObjectActions
 from .models import Place
 
-# Register your models here.
-admin.site.register(Place)
+# Adds a button to the Person Admin page to allow users to manually update the
+# directory screens with the most up-to-date data
+class PlaceAdmin(DjangoObjectActions, admin.ModelAdmin):
+
+  def UpdateScreens(self, request, queryset):
+    load_rollup()
+    self.message_user(request, 'Successfully updated screens with revised person and place data.', level=messages.SUCCESS, fail_silently=False)
+  
+  UpdateScreens.label = 'Update screens'
+        
+  changelist_actions = ('UpdateScreens', )
+
+admin.site.register(Place, PlaceAdmin)

--- a/app/place/admin.py
+++ b/app/place/admin.py
@@ -1,18 +1,5 @@
-from django.contrib import admin, messages
-from rollup.utils import load_rollup
-from django_object_actions import DjangoObjectActions
+from django.contrib import admin
+from rollup.utils import load_rollup, UpdateScreens
 from .models import Place
 
-# Adds a button to the Person Admin page to allow users to manually update the
-# directory screens with the most up-to-date data
-class PlaceAdmin(DjangoObjectActions, admin.ModelAdmin):
-
-  def UpdateScreens(self, request, queryset):
-    load_rollup()
-    self.message_user(request, 'Successfully updated screens with revised person and place data.', level=messages.SUCCESS, fail_silently=False)
-  
-  UpdateScreens.label = 'Update screens'
-        
-  changelist_actions = ('UpdateScreens', )
-
-admin.site.register(Place, PlaceAdmin)
+admin.site.register(Place, UpdateScreens)

--- a/app/place/tests.py
+++ b/app/place/tests.py
@@ -45,7 +45,8 @@ class PlaceTestCase(TestCase):
 
     c = Client()
     c.login(username=test_username, password=test_password)
-    response = c.get('/admin/place/place/actions/UpdateScreens/', follow=True)
+    with disable_auto_indexing():
+      response = c.get('/admin/place/place/actions/UpdateScreens/', follow=True)
 
     self.assertEqual(response.status_code, 200)
     self.assertTrue(success_message in response.content.decode('utf-8'))

--- a/app/place/tests.py
+++ b/app/place/tests.py
@@ -1,6 +1,13 @@
-from django.test import TestCase
+from django.test import TestCase, Client
+from django.contrib.auth.models import User
 
 from .models import Place
+
+test_username = 'test'
+test_email = 'test@test.com'
+test_password = 'TesterPassword'
+update_screens_button_label = 'Update screens'
+success_message = 'Successfully updated screens with revised person and place data.'
 
 # Create your tests here.
 class PlaceTestCase(TestCase):
@@ -22,3 +29,23 @@ class PlaceTestCase(TestCase):
     place = Place.objects.get(id=1)
     label = place._meta.get_field('location').verbose_name
     self.assertEqual(label, 'Location')
+  
+  def test_update_screens_button_renders(self):
+    User.objects.create_superuser(test_username, test_email, test_password)
+
+    c = Client()
+    c.login(username=test_username, password=test_password)
+    response = c.get('/admin/place/place/')
+  
+    self.assertEqual(response.status_code, 200)
+    self.assertTrue(update_screens_button_label in response.content.decode('utf-8'))
+
+  def test_click_update_screens_button_result(self):
+    User.objects.create_superuser(test_username, test_email, test_password)
+
+    c = Client()
+    c.login(username=test_username, password=test_password)
+    response = c.get('/admin/place/place/actions/UpdateScreens/', follow=True)
+
+    self.assertEqual(response.status_code, 200)
+    self.assertTrue(success_message in response.content.decode('utf-8'))

--- a/app/place/tests.py
+++ b/app/place/tests.py
@@ -1,6 +1,8 @@
 from django.test import TestCase, Client
 from django.contrib.auth.models import User
 from algoliasearch_django.decorators import disable_auto_indexing
+import requests
+from unittest.mock import patch
 
 from .models import Place
 
@@ -9,6 +11,7 @@ test_email = 'test@test.com'
 test_password = 'TesterPassword'
 update_screens_button_label = 'Update screens'
 success_message = 'Successfully updated screens with revised person and place data.'
+error_message = 'Error: Unable to update screens. If the problem persists, contact SEAS Computing.'
 c = Client()
 
 # Create your tests here.
@@ -34,15 +37,22 @@ class PlaceTestCase(TestCase):
     label = place._meta.get_field('location').verbose_name
     self.assertEqual(label, 'Location')
   
-  def test_update_screens_button_renders(self):
+  def test_place_update_screens_button_renders(self):
     response = c.get('/admin/place/place/')
   
     self.assertEqual(response.status_code, 200)
     self.assertTrue(update_screens_button_label in response.content.decode('utf-8'))
 
-  def test_click_update_screens_button_result(self):
+  def test_click_place_update_screens_button_result(self):
     with disable_auto_indexing():
-      response = c.get('/admin/place/place/actions/UpdateScreens/', follow=True)
+      response = c.get('/admin/place/place/actions/UpdateScreensButton/', follow=True)
 
     self.assertEqual(response.status_code, 200)
     self.assertTrue(success_message in response.content.decode('utf-8'))
+  
+  @patch('rollup.utils.load_rollup')
+  def test_click_place_update_screens_button_error(self, mock_load_rollup):
+    mock_load_rollup.side_effect = Exception('Test error')
+    with disable_auto_indexing():
+      response = c.get('/admin/place/place/actions/UpdateScreensButton/', follow=True)
+    self.assertTrue(error_message in response.content.decode('utf-8'))

--- a/app/place/tests.py
+++ b/app/place/tests.py
@@ -1,5 +1,6 @@
 from django.test import TestCase, Client
 from django.contrib.auth.models import User
+from algoliasearch_django.decorators import disable_auto_indexing
 
 from .models import Place
 

--- a/app/place/tests.py
+++ b/app/place/tests.py
@@ -9,6 +9,7 @@ test_email = 'test@test.com'
 test_password = 'TesterPassword'
 update_screens_button_label = 'Update screens'
 success_message = 'Successfully updated screens with revised person and place data.'
+c = Client()
 
 # Create your tests here.
 class PlaceTestCase(TestCase):
@@ -16,6 +17,8 @@ class PlaceTestCase(TestCase):
   @classmethod
   def setUpTestData(cls):
     place = Place.objects.create(name="SEC", location="150 Western Ave, Allston, MA 02134")
+    User.objects.create_superuser(test_username, test_email, test_password)
+    c.login(username=test_username, password=test_password)
   
   def test_str_value(self):
     place = Place.objects.get(id=1)
@@ -32,20 +35,12 @@ class PlaceTestCase(TestCase):
     self.assertEqual(label, 'Location')
   
   def test_update_screens_button_renders(self):
-    User.objects.create_superuser(test_username, test_email, test_password)
-
-    c = Client()
-    c.login(username=test_username, password=test_password)
     response = c.get('/admin/place/place/')
   
     self.assertEqual(response.status_code, 200)
     self.assertTrue(update_screens_button_label in response.content.decode('utf-8'))
 
   def test_click_update_screens_button_result(self):
-    User.objects.create_superuser(test_username, test_email, test_password)
-
-    c = Client()
-    c.login(username=test_username, password=test_password)
     with disable_auto_indexing():
       response = c.get('/admin/place/place/actions/UpdateScreens/', follow=True)
 

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -3,3 +3,4 @@ gunicorn==20.0.4
 psycopg2
 beautifulsoup4==4.9.3
 algoliasearch-django>=2.0,<3.0
+django_object_actions

--- a/app/rollup/tests.py
+++ b/app/rollup/tests.py
@@ -17,11 +17,11 @@ class RollupTestCase(TestCase):
       Rollup.objects.create(name="Jane Smith", location="SEC Room 142")
       Rollup.objects.create(name="SEC", location="150 Western Ave, Allston, MA 02134")
       Rollup.objects.create(name="114 Western Ave", location="114 Western Ave, Allston, MA 02134")
-    # Data that should be converted to Rollup objects after calling load_rollup
-    place = Place.objects.create(name="Soldier's Field Park Children's Center", location="114 Western Ave, Allston, MA 02134")
-    person = Person.objects.create(firstname="Jane", lastname="Harvard", location="SEC Room 322", name="Jane Harvard")
-    feed_person = FeedPerson.objects.create(eppn="1a2b3c456def7890", firstname="John", lastname="Harvard", location="Pierce Hall 101", name="John Harvard")
-    load_rollup()
+      # Data that should be converted to Rollup objects after calling load_rollup
+      place = Place.objects.create(name="Soldier's Field Park Children's Center", location="114 Western Ave, Allston, MA 02134")
+      person = Person.objects.create(firstname="Jane", lastname="Harvard", location="SEC Room 322", name="Jane Harvard")
+      feed_person = FeedPerson.objects.create(eppn="1a2b3c456def7890", firstname="John", lastname="Harvard", location="Pierce Hall 101", name="John Harvard")
+      load_rollup()
 
   def test_rollup_removes_original_data(self):
     self.assertEqual(Rollup.objects.filter(name="John Smith").count(), 0)

--- a/app/rollup/utils.py
+++ b/app/rollup/utils.py
@@ -1,7 +1,10 @@
+from django.contrib import admin, messages
+from django_object_actions import DjangoObjectActions
 from .models import Rollup
 from place.models import Place
 from person.models import Person
 from feedperson.models import FeedPerson
+import logging
 
 # Creates updated Rollup objects using Place, Person, and FeedPerson data
 def load_rollup():
@@ -16,3 +19,22 @@ def load_rollup():
         name = object.name,
         location = object.location
       )
+
+# Get an instance of a logger
+logger = logging.getLogger(__name__)
+
+class UpdateScreens(DjangoObjectActions, admin.ModelAdmin):
+
+  def UpdateScreensButton(self, request, queryset):
+    try:
+      load_rollup()
+      self.message_user(request, 'Successfully updated screens with revised person and place data.', level=messages.SUCCESS, fail_silently=False)
+    except Exception as err:
+      logger.exception(err)
+      self.message_user(request, 'Error: Unable to update screens. If the problem persists, contact SEAS Computing.', level=messages.ERROR, fail_silently=False)
+    
+  UpdateScreensButton.label = 'Update screens'
+
+  UpdateScreensButton.short_description = 'Manually refresh the screens with the most recent data.'
+        
+  changelist_actions = ('UpdateScreensButton', )


### PR DESCRIPTION
This PR adds an "Update Screens" button to Django Admin for both `People` and `Places.` Clicking the button calls `load_rollup(),` and on successful completion, a success message will appear in Django Admin:

![image](https://user-images.githubusercontent.com/29589689/131516581-6c79b4b5-417c-45f4-91af-fd56477d4bc4.png)