### PR TITLE
Added a couple of regexes to fix locations on import. 

### DIFF
--- a/app/feedperson/tests.py
+++ b/app/feedperson/tests.py
@@ -38,6 +38,12 @@ class LoadFeedTest(TestCase):
   def test_load_feed_people_regex_sec_is_there(self):
     sec_people = filter(lambda person: "SEC" in person.location, FeedPerson.objects.all())
     self.assertTrue(len(list(sec_people)) > 0)
+  
+  def test_load_feed_people_regex_wester_ave_versions_changes(self):
+    western_ave_people = filter(lambda person: "Western Ave " in person.location, FeedPerson.objects.all())
+    western_ave_comma_people = filter(lambda person: "Western Ave," in person.location, FeedPerson.objects.all())
+    self.assertEqual(len(list(western_ave_people)), 0)
+    self.assertEqual(len(list(western_ave_comma_people)), 0)
 
   def test_load_feed_people_removes_original_data(self):
     feed_person = FeedPerson.objects.create(eppn="1a2b3c456def7890", firstname="John", lastname="Harvard", location="Pierce Hall 101", name="John Harvard")

--- a/app/feedperson/tests.py
+++ b/app/feedperson/tests.py
@@ -14,16 +14,29 @@ class FeedPersonTestCase(TestCase):
     feed_person = FeedPerson.objects.get(id=1)
     self.assertEqual(feed_person.name, str(feed_person))
 
-  def test_load_feed_people_removes_original_data(self):
-    feed_person = FeedPerson.objects.get(id=1)
+class LoadFeedTest(TestCase):
+  
+  @classmethod
+  def setUpTestData(cls):
     with disable_auto_indexing():
       load_feed_people()
-    self.assertEqual(FeedPerson.objects.filter(eppn=feed_person.eppn).count(), 0)
 
   def test_load_feed_people_imports_western_ave_people(self):
-    with disable_auto_indexing():
-      load_feed_people()
     western_ave_people = filter(lambda person: "Western Ave" in person.location, FeedPerson.objects.all())
     non_western_ave_people = filter(lambda person: "Western Ave" not in person.location, FeedPerson.objects.all())
     self.assertTrue(len(list(western_ave_people)) > 0)
     self.assertEqual(len(list(non_western_ave_people)), 0)
+
+  def test_load_feed_people_regex_removes_all_SciEnG(self):
+    scieng_people = filter(lambda person: "Sci&Eng" in person.location, FeedPerson.objects.all())
+    self.assertTrue(len(list(scieng_people)) == 0)
+
+  def test_load_feed_people_regex_removes_all_western_avenue(self):
+    western_avenue_people = filter(lambda person: "Western Avenue" in person.location, FeedPerson.objects.all())
+    self.assertTrue(len(list(western_avenue_people)) == 0)
+
+  def test_load_feed_people_removes_original_data(self):
+    feed_person = FeedPerson.objects.create(eppn="1a2b3c456def7890", firstname="John", lastname="Harvard", location="Pierce Hall 101", name="John Harvard")
+    with disable_auto_indexing():
+      load_feed_people()
+    self.assertEqual(FeedPerson.objects.filter(eppn=feed_person.eppn).count(), 0)

--- a/app/feedperson/tests.py
+++ b/app/feedperson/tests.py
@@ -29,11 +29,15 @@ class LoadFeedTest(TestCase):
 
   def test_load_feed_people_regex_removes_all_SciEnG(self):
     scieng_people = filter(lambda person: "Sci&Eng" in person.location, FeedPerson.objects.all())
-    self.assertTrue(len(list(scieng_people)) == 0)
+    self.assertEqual(len(list(scieng_people)), 0)
 
   def test_load_feed_people_regex_removes_all_western_avenue(self):
     western_avenue_people = filter(lambda person: "Western Avenue" in person.location, FeedPerson.objects.all())
-    self.assertTrue(len(list(western_avenue_people)) == 0)
+    self.assertEqual(len(list(western_avenue_people)), 0)
+
+  def test_load_feed_people_regex_sec_is_there(self):
+    sec_people = filter(lambda person: "SEC" in person.location, FeedPerson.objects.all())
+    self.assertTrue(len(list(sec_people)) > 0)
 
   def test_load_feed_people_removes_original_data(self):
     feed_person = FeedPerson.objects.create(eppn="1a2b3c456def7890", firstname="John", lastname="Harvard", location="Pierce Hall 101", name="John Harvard")

--- a/app/feedperson/utils.py
+++ b/app/feedperson/utils.py
@@ -19,6 +19,13 @@ def load_feed_people():
   for person in people:
     location = person.location.fordisp.text
     if (re.match('114 Western Ave', location) or re.match('150 Western Ave', location)):
+      
+      # This regex is a temp fix whilst the location data is inconsistent in PeopleSoft.
+      # Should be removed once the data is fixed.
+      if re.match('150 Western Ave', location):
+        location = re.sub(r'Sci&Eng', 'SEC', location)
+        location = re.sub(r'150 Western Avenue', '150 Western Ave, SEC', location)
+      
       FeedPerson.objects.create(
         eppn=person.eppn.text,
         firstname=person.givenname.text,

--- a/app/feedperson/utils.py
+++ b/app/feedperson/utils.py
@@ -25,7 +25,7 @@ def load_feed_people():
         location = re.sub(r'Sci&Eng', 'SEC', location)
 
         # This allows for multiple spaces between words, and it allows the pattern to be "150 Western Ave", "150 Western Ave.", or "150 Western Avenue".
-        # Also, in case the original string already contains "SEC," we could include "SEC" in the pattern so that the result does not have "SEC" twice
+        # Also, in case the original string already contains "SEC," we include "SEC" in the pattern so that the result does not have "SEC" twice
         # (e.g. "150 Western Ave, SEC, SEC" as the final resulting string)
         location = re.sub(r'\b150\s+Western\s+Ave(?:\.|nue)?(?:,\s*SEC)?', "150 Western Ave. SEC", location, flags=re.IGNORECASE)
 

--- a/app/feedperson/utils.py
+++ b/app/feedperson/utils.py
@@ -19,13 +19,16 @@ def load_feed_people():
   for person in people:
     location = person.location.fordisp.text
     if (re.match('114 Western Ave', location) or re.match('150 Western Ave', location)):
-      
       # This regex is a temp fix whilst the location data is inconsistent in PeopleSoft.
       # Should be removed once the data is fixed.
       if re.match('150 Western Ave', location):
         location = re.sub(r'Sci&Eng', 'SEC', location)
-        location = re.sub(r'150 Western Avenue', '150 Western Ave, SEC', location)
-      
+
+        # This allows for multiple spaces between words, and it allows the pattern to be "150 Western Ave", "150 Western Ave.", or "150 Western Avenue".
+        # Also, in case the original string already contains "SEC," we could include "SEC" in the pattern so that the result does not have "SEC" twice
+        # (e.g. "150 Western Ave, SEC, SEC" as the final resulting string)
+        location = re.sub(r'\b150\s+Western\s+Ave(?:\.|nue)?(?:,\s*SEC)?', "150 Western Ave. SEC", location, flags=re.IGNORECASE)
+
       FeedPerson.objects.create(
         eppn=person.eppn.text,
         firstname=person.givenname.text,


### PR DESCRIPTION
The regexes replace the strings "Sci&Eng" and Western Avenue, with a standard "150 Western Ave, SEC". Whilst writing the tests I found that I was calling `load_feed_people()` so many times that it was taking over 30 seconds to complete the tests. By splitting into two test cases and pushing `load_feed_people()` into the `setUpTestData` function it cuts down the test run time to ~15 seconds. 