### PR TITLE
Correct Dockerfile location

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -70,6 +70,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: app
-          file: ./Dockerfile
+          file: ./app/Dockerfile
           push: true
           tags: ghcr.io/${{ github.repository }}:stable


### PR DESCRIPTION
Early in the process of #31 I had moved the Dockerfile into the root of
the repository and had updated this workflow file to use that location.
While testing that setup, I found that I needed to move the Dockerfile
back under the /app directory so that it would be included properly as
part of the docker context. Of course, when I made that change I
neglected to also update the workflow file, so when #31 was merged the
build step failed.

This restores the previous location and should fix the build issues.