### PR TITLE
Changed STATIC_URL to take an environment variable

### DIFF
--- a/app/app/settings/base.py
+++ b/app/app/settings/base.py
@@ -129,7 +129,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.1/howto/static-files/
 
 STATIC_ROOT = path.join(BASE_DIR, 'static')
-STATIC_URL = '/static/'
+STATIC_URL = environ.get("STATIC_URL", '/static/')
 MEDIA_ROOT = path.join(BASE_DIR, 'media')
 MEDIA_URL = '/media/'
 

--- a/app/app/settings/base.py
+++ b/app/app/settings/base.py
@@ -130,8 +130,10 @@ USE_TZ = True
 
 STATIC_ROOT = path.join(BASE_DIR, 'static')
 STATIC_URL = environ.get("STATIC_URL", '/static/')
-MEDIA_ROOT = path.join(BASE_DIR, 'media')
-MEDIA_URL = '/media/'
+
+### MEDIA_ROOT and MEDIA_URL not required for this project as no files are being uploaded by users.
+# MEDIA_ROOT = path.join(BASE_DIR, 'media')
+# MEDIA_URL = '/media/'
 
 # Algolia Search Setup
 # https://www.algolia.com/doc/framework-integration/django/setup/?client=python#setup

--- a/template.env
+++ b/template.env
@@ -82,3 +82,10 @@ ALGOLIA_INDEX=
 #NOTE: THIS SHOULD NOT BE AN ADMIN KEY.
 # See: https://www.algolia.com/doc/guides/security/api-keys/
 ALGOLIA_API_KEY=
+
+
+# This overides the default URL for static files included in the Django admin templates.
+# This should be used to include the S3 bucket URL that we are using to store the static files. 
+# For local development purposes this can be left commented out.
+#
+# STATIC_URL=


### PR DESCRIPTION
This PR changes the STATIC_URL parameter in the base settings file to take the STATIC_URL environment variable, allowing us to point to S3 for static files in dev/production. The STATIC_URL environment variable should be a string of the full S3 bucket URL with the `/static/` path appended.