### PR TITLE
Add reindex mode to entrypoint

### DIFF
--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -7,6 +7,8 @@ if [[ "$*" == "--production" ]]; then
   EXEC_MODE=production
 elif [[ "$*" == "--development" ]]; then
   EXEC_MODE=development
+elif [[ "$*" == "--reindex" ]]; then
+  EXEC_MODE=reindex
 fi
 
 if [ "$DATABASE" = "postgres" ]
@@ -23,6 +25,12 @@ fi
 if [[ $EXEC_MODE == exec ]]; then
   echo "Running $@"
   exec "$@"
+elif [[ $EXEC_MODE == reindex ]]; then
+  echo "Reindexing Database"
+  python manage.py shell\
+    --command="from feedperson.utils import load_feed_people;\
+    load_feed_people()"
+  python manage.py algolia_reindex
 else
   python manage.py migrate
   python manage.py createsuperuser --noinput

--- a/app/feedperson/utils.py
+++ b/app/feedperson/utils.py
@@ -16,6 +16,7 @@ def load_feed_people():
 
   people = soup.findAll('person')
 
+  counter = 0;
   for person in people:
     location = person.location.fordisp.text
     if (re.match('114 Western Ave', location) or re.match('150 Western Ave', location)):
@@ -29,6 +30,7 @@ def load_feed_people():
         # (e.g. "150 Western Ave, SEC, SEC" as the final resulting string)
         location = re.sub(r'\b150\s+Western\s+Ave(?:\.|nue)?(?:,\s*SEC)?', "150 Western Ave. SEC", location, flags=re.IGNORECASE)
 
+      counter += 1
       FeedPerson.objects.create(
         eppn=person.eppn.text,
         firstname=person.givenname.text,
@@ -37,5 +39,5 @@ def load_feed_people():
         location=location
       )
   
+  print('Loaded ' + str(counter) + ' people in Allston')
   load_rollup()
-


### PR DESCRIPTION
To avoid any weirdness with the exec environment, this lets you pass `--reindex` to the docker run command, which will run the `load_feed_people` function then manually trigger a reindexing. It will log the number of people found in the feed, and then log the number of records indexed in Algolia to allow for manual validation.