### PR TITLE
Use SERVER_PORT variable to set listen port

### DIFF
--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -11,6 +11,11 @@ elif [[ "$*" == "--reindex" ]]; then
   EXEC_MODE=reindex
 fi
 
+# Default to SERVER_PORT 8000
+if [[ -z "$SERVER_PORT" ]]; then
+  SERVER_PORT=8000
+fi
+
 if [ "$DATABASE" = "postgres" ]
 then
   echo "Waiting for postgres..."
@@ -36,9 +41,9 @@ else
   python manage.py createsuperuser --noinput
   if [[ $EXEC_MODE == development ]]; then
     echo "Starting app in development mode..."
-    python manage.py runserver 0.0.0.0:8000
+    python manage.py runserver 0.0.0.0:$SERVER_PORT
   elif [[ $EXEC_MODE == production ]]; then
     echo "Starting App in production mode..."
-    gunicorn app.wsgi:application --bind 0.0.0.0:8000
+    gunicorn app.wsgi:application --bind 0.0.0.0:$SERVER_PORT
   fi
 fi

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -19,7 +19,6 @@ services:
       DEBUG: 0
       DJANGO_SETTINGS_MODULE: app.settings.production
       SQL_HOST: db_prod
-      SERVER_PORT:
 
   db_prod:
     image: postgres:12.0-alpine

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,13 +10,16 @@ services:
       - static_volume_prod:/home/app/web/app/static
       - media_volume_prod:/home/app/web/app/media
     expose:
-      - 8000
+      - ${SERVER_PORT}
+    ports:
+      - 127.0.0.1:${SERVER_PORT}:${SERVER_PORT}
     env_file:
       - ./.env
     environment:
       DEBUG: 0
       DJANGO_SETTINGS_MODULE: app.settings.production
       SQL_HOST: db_prod
+      SERVER_PORT:
 
   db_prod:
     image: postgres:12.0-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,11 @@ services:
     volumes:
       - ./app/:/usr/src/app/
     ports:
-      - 127.0.0.1:8000:8000
+      - 127.0.0.1:${SERVER_PORT}:${SERVER_PORT}
     env_file: .env
     environment:
       DEBUG: 0
+      SERVER_PORT:
 
   db:
     image: postgres:12.0-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ services:
     env_file: .env
     environment:
       DEBUG: 0
-      SERVER_PORT:
 
   db:
     image: postgres:12.0-alpine

--- a/template.env
+++ b/template.env
@@ -15,6 +15,9 @@ DJANGO_ALLOWED_HOSTS=localhost 127:0.0.1 [::1]
 # See: https://docs.djangoproject.com/en/3.1/topics/settings/#envvar-DJANGO_SETTINGS_MODULE
 DJANGO_SETTINGS_MODULE=app.settings.dev
 
+# The port on which the application should listen
+SERVER_PORT=8000
+
 #
 # Database Configuration
 #


### PR DESCRIPTION
Previously, we were hard-coding port `8000` into our configs; however, our cloudformation template for launching the app was asking it as a parameter. That is more in line with our usual configuration, so we can update our entrypoint script to use that value instead.

For testing purposes, it should be sufficient to:

1. Add the `SERVER_PORT` to the .env file with a value
2. run `docker-compose up` 
3. Visit localhost:${SERVER_PORT}/admin` and confirm that the login page appears.
