### PR TITLE
Fail database check after two minutes

### DIFF
--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+DATE_FMT="%Y-%m-%d %H:%M:%S %z"
+
 # default to development mode
 EXEC_MODE=exec
 
@@ -19,25 +21,25 @@ fi
 # Attempt to connect to the postgres port, bailing after two minutes
 if [[ $DATABASE == postgres ]]
 then
-  echo "Waiting for postgres..."
-
+  echo [$(date +"$DATE_FMT")] [$$] [INFO] Waiting for postgres...
   let COUNT=0
   while ! nc -z $SQL_HOST $SQL_PORT; do
     sleep 2
     let COUNT=$COUNT+1
     if [[ $COUNT -ge 60 ]]; then
+      echo [$(date +"$DATE_FMT")] [$$] [ERROR] Could not reach Postgres
       exit 1
     fi
   done
 
-  echo "PostgreSQL started"
+  echo [$(date +"$DATE_FMT")] [$$] [INFO] PostgreSQL started
 fi
 
 if [[ $EXEC_MODE == exec ]]; then
-  echo "Running $@"
+  echo [$(date +"$DATE_FMT")] [$$] [INFO] Running $@
   exec "$@"
 elif [[ $EXEC_MODE == reindex ]]; then
-  echo "Reindexing Database"
+  echo [$(date +"$DATE_FMT")] [$$] [INFO] Reindexing Database
   python manage.py shell\
     --command="from feedperson.utils import load_feed_people;\
     load_feed_people()"
@@ -46,10 +48,10 @@ else
   python manage.py migrate
   python manage.py createsuperuser --noinput
   if [[ $EXEC_MODE == development ]]; then
-    echo "Starting app in development mode..."
+    echo [$(date +"$DATE_FMT")] [$$] [INFO] Starting app in development mode...
     python manage.py runserver 0.0.0.0:$SERVER_PORT
   elif [[ $EXEC_MODE == production ]]; then
-    echo "Starting App in production mode..."
+    echo [$(date +"$DATE_FMT")] [$$] [INFO] Starting App in production mode...
     gunicorn app.wsgi:application --bind 0.0.0.0:$SERVER_PORT
   fi
 fi

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -16,12 +16,18 @@ if [[ -z "$SERVER_PORT" ]]; then
   SERVER_PORT=8000
 fi
 
-if [ "$DATABASE" = "postgres" ]
+# Attempt to connect to the postgres port, bailing after two minutes
+if [[ $DATABASE == postgres ]]
 then
   echo "Waiting for postgres..."
 
+  let COUNT=0
   while ! nc -z $SQL_HOST $SQL_PORT; do
-    sleep 0.1
+    sleep 2
+    let COUNT=$COUNT+1
+    if [[ $COUNT -ge 60 ]]; then
+      exit 1
+    fi
   done
 
   echo "PostgreSQL started"


### PR DESCRIPTION
This fixes a potential infinite loop issue with the entrypoint script, which was uncovered when the ops team was attempting to run the periodic task container with a security group that did not provide access to the database. The container would start and hang at the "Waiting for Postgres..." stage, then the next day another container would start and hang, and continue until we had three containers running and doing nothing.

Now it:

1) Waits longer between rechecking the database
2) Stop checking the database after two minutes
3) Provides more descriptive logging output

That last point is somewhat unrelated, but came to light during the same testing session that revealed the first issue. Eventually all of these logs are going to be sent to our Splunk service, and we want to make sure that there are dates and status levels that can be easily parsed on the other end. I set up the default messages to mirror the output of `gunicorn`, so we're also printing the process id (via the `$$` variable).