### PR TITLE
Update base container to python:3.8-alpine

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -2,7 +2,7 @@
 # This layer installs all of the system packages necessary for compiling/installing dependencies
 
 # pull official base image
-FROM python:3.8.0-alpine as base
+FROM python:3.8-alpine as base
 
 # set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1
@@ -47,7 +47,7 @@ RUN pip install --prefix=/install -r requirements.txt
 
 # PRODUCTION 
 # Our final image, based off a fresh alpine image
-FROM python:3.8.0-alpine as production
+FROM python:3.8-alpine as production
 
 # set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1


### PR DESCRIPTION
The `python:3.8.0-alpine` container is using an EOL version of alpine (`3.10.3`), but dropping the `.0` patch level will make it use up-to-date versions of both python (`3.8.15`) and alpine (`3.16.3`). Those versions go EOL in October 2024 and May 2024, respectively, so that does give us some runway to set a more formal and consistent upgrade process.